### PR TITLE
Add mutex for err var

### DIFF
--- a/azblob/chunkwriting.go
+++ b/azblob/chunkwriting.go
@@ -188,8 +188,11 @@ func (c *copier) close() error {
 // waitForFinish waits for all writes to complete while combining errors from errCh
 func (c *copier) waitForFinish() error {
 	var err error
+	var mu sync.Mutex
 	done := make(chan struct{})
+	mu.Lock()
 	go func() {
+		defer mu.Unlock()
 		// when write latencies are long, several errors might have occurred
 		// drain them all as we wait for writes to complete.
 		err = c.drainErrs(done)
@@ -197,6 +200,9 @@ func (c *copier) waitForFinish() error {
 
 	c.wg.Wait()
 	close(done)
+
+	mu.Lock()
+	defer mu.Unlock()
 	return err
 }
 


### PR DESCRIPTION
Before fix:
```
go test ./... -count=10 -run TestSlowDestCopyFrom  -race
==================
WARNING: DATA RACE
Write at 0x00c0001a8040 by goroutine 11:
  github.com/Azure/azure-storage-blob-go/azblob.(*copier).waitForFinish.func1()
      /Users/progers/dev/src/github.com/paul1r/azure-storage-blob-go/azblob/chunkwriting.go:198 +0x50

Previous read at 0x00c0001a8040 by goroutine 8:
  github.com/Azure/azure-storage-blob-go/azblob.(*copier).waitForFinish()
      /Users/progers/dev/src/github.com/paul1r/azure-storage-blob-go/azblob/chunkwriting.go:206 +0x168
  github.com/Azure/azure-storage-blob-go/azblob.(*copier).close()
      /Users/progers/dev/src/github.com/paul1r/azure-storage-blob-go/azblob/chunkwriting.go:179 +0x30
  github.com/Azure/azure-storage-blob-go/azblob.copyFromReader()
      /Users/progers/dev/src/github.com/paul1r/azure-storage-blob-go/azblob/chunkwriting.go:64 +0x414
  github.com/Azure/azure-storage-blob-go/azblob.TestSlowDestCopyFrom.func2()
      /Users/progers/dev/src/github.com/paul1r/azure-storage-blob-go/azblob/chunkwriting_test.go:196 +0x88

Goroutine 11 (running) created at:
  github.com/Azure/azure-storage-blob-go/azblob.(*copier).waitForFinish()
      /Users/progers/dev/src/github.com/paul1r/azure-storage-blob-go/azblob/chunkwriting.go:194 +0x148
  github.com/Azure/azure-storage-blob-go/azblob.(*copier).close()
      /Users/progers/dev/src/github.com/paul1r/azure-storage-blob-go/azblob/chunkwriting.go:179 +0x30
  github.com/Azure/azure-storage-blob-go/azblob.copyFromReader()
      /Users/progers/dev/src/github.com/paul1r/azure-storage-blob-go/azblob/chunkwriting.go:64 +0x414
  github.com/Azure/azure-storage-blob-go/azblob.TestSlowDestCopyFrom.func2()
      /Users/progers/dev/src/github.com/paul1r/azure-storage-blob-go/azblob/chunkwriting_test.go:196 +0x88

Goroutine 8 (running) created at:
  github.com/Azure/azure-storage-blob-go/azblob.TestSlowDestCopyFrom()
      /Users/progers/dev/src/github.com/paul1r/azure-storage-blob-go/azblob/chunkwriting_test.go:195 +0x278
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.6/libexec/src/testing/testing.go:1648 +0x40
==================
--- FAIL: TestSlowDestCopyFrom (0.44s)
    testing.go:1465: race detected during execution of test
```

After fix:
```
go test ./... -count=10 -run TestSlowDestCopyFrom  -race
ok  	github.com/Azure/azure-storage-blob-go/azblob	5.516s
```